### PR TITLE
Make vesting contract sn contrib factory immutable as its upgradable

### DIFF
--- a/contracts/interfaces/ITokenVestingStaking.sol
+++ b/contracts/interfaces/ITokenVestingStaking.sol
@@ -150,11 +150,6 @@ interface ITokenVestingStaking {
     /// rewards. See notes on `snContribBeneficiary` for `contributeFunds`.
     function updateBeneficiary(address snContribAddr, address snContribBeneficiary) external;
 
-    /// @notice Allows the revoker to change the multi-contributor factory which
-    /// determines if contribution addresses are valid.
-    /// @param factoryAddr ServiceNodeContributionFactory address to update.
-    function updateContributionFactory(address factoryAddr) external;
-
     //////////////////////////////////////////////////////////////
     //                                                          //
     //             Investor contract functions                  //

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -77,7 +77,7 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
     // solhint-disable-next-line var-name-mixedcase
     IERC20                          public immutable SESH;
     IServiceNodeRewards             public immutable rewardsContract;
-    IServiceNodeContributionFactory public           snContribFactory;
+    IServiceNodeContributionFactory public immutable snContribFactory;
 
     //////////////////////////////////////////////////////////////
     //                                                          //
@@ -192,10 +192,6 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
     ) external onlyRevokerIfRevokedElseBeneficiary afterStart nzAddr(snContribBeneficiary) {
         IServiceNodeContribution snContrib = getContributionContract(snContribAddr);
         snContrib.updateBeneficiary(snContribBeneficiary);
-    }
-
-    function updateContributionFactory(address factoryAddr) external override onlyRevoker nzAddr(factoryAddr) {
-        snContribFactory = IServiceNodeContributionFactory(factoryAddr);
     }
 
     //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Made the multi contrib factory immutable in the Staking Vesting Contract and removed the update function for it. Now that the factory is upgradeable this is not needed